### PR TITLE
ui: customize homepage

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -65,3 +65,4 @@ recursive-include ui *.prettierignore
 recursive-include ui *.prettierrc
 recursive-include ui *.txt
 recursive-include ui *.variables
+recursive-include ui *.svg

--- a/ui/craco.config.js
+++ b/ui/craco.config.js
@@ -9,21 +9,41 @@ module.exports = {
   },
   webpack: {
     alias: {
-      // react-searchkit peer dependencies, to avoid duplication
+      // aliases for all peer dependencies to avoid double libraries
+      '@babel/runtime': path.resolve('./node_modules/@babel/runtime'),
       axios: path.resolve('./node_modules/axios'),
       formik: path.resolve('./node_modules/formik'),
+      less: path.resolve('./node_modules/less'),
+      'less-loader': path.resolve('./node_modules/less-loader'),
       lodash: path.resolve('./node_modules/lodash'),
       luxon: path.resolve('./node_modules/luxon'),
+      path: path.resolve('./node_modules/path'),
       'prop-types': path.resolve('./node_modules/prop-types'),
       qs: path.resolve('./node_modules/qs'),
       react: path.resolve('./node_modules/react'),
+      'react-app-polyfill': path.resolve('./node_modules/react-app-polyfill'),
+      'react-copy-to-clipboard': path.resolve(
+        './node_modules/react-copy-to-clipboard'
+      ),
       'react-dom': path.resolve('./node_modules/react-dom'),
       'react-overridable': path.resolve('./node_modules/react-overridable'),
-      'react-searchkit': path.resolve('./node_modules/react-searchkit'),
       'react-redux': path.resolve('./node_modules/react-redux'),
+      'react-router-dom': path.resolve('./node_modules/react-router-dom'),
+      'react-scroll': path.resolve('./node_modules/react-scroll'),
+      'react-searchkit': path.resolve('./node_modules/react-searchkit'),
+      'react-show-more': path.resolve('./node_modules/react-show-more'),
+      'react-tagcloud': path.resolve('./node_modules/react-tagcloud'),
       redux: path.resolve('./node_modules/redux'),
+      'redux-devtools-extension': path.resolve(
+        './node_modules/redux-devtools-extension'
+      ),
       'redux-thunk': path.resolve('./node_modules/redux-thunk'),
+      'semantic-ui-calendar-react': path.resolve(
+        './node_modules/semantic-ui-calendar-react'
+      ),
+      'semantic-ui-less': path.resolve('./node_modules/semantic-ui-less'),
+      'semantic-ui-react': path.resolve('./node_modules/semantic-ui-react'),
       yup: path.resolve('./node_modules/yup'),
     },
-  }
+  },
 };

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1285,9 +1285,9 @@
       }
     },
     "@inveniosoftware/react-invenio-app-ils": {
-      "version": "1.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@inveniosoftware/react-invenio-app-ils/-/react-invenio-app-ils-1.0.0-alpha.3.tgz",
-      "integrity": "sha512-OGlbbvAVZkwmmOGJwL7VD7aqEEdYiMauqopuTkbW1xgAwpsLcTcgqQnqZyjbk33HRDJtSrIcw/hoUzJK7QjfQw=="
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@inveniosoftware/react-invenio-app-ils/-/react-invenio-app-ils-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-GEGyUwTaQt9Fy0JgoiySKvj9sof5wItQi6GOLdANDZd+WRmzfND6JU4/We3R7K3UNbg0rV8LCFljTvrAQR4fzg=="
     },
     "@jest/console": {
       "version": "24.9.0",
@@ -3075,16 +3075,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -6224,13 +6214,6 @@
         "schema-utils": "^2.5.0"
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -8095,11 +8078,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         }
       }
     },
@@ -9345,13 +9324,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -14866,11 +14838,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -15244,11 +15212,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "get-caller-file": {
           "version": "1.0.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0a2",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.3",
+    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.4",
     "axios": "^0.19.2",
     "formik": "^2.1.4",
     "less": "^3.11.1",

--- a/ui/public/logo-invenio-ils.svg
+++ b/ui/public/logo-invenio-ils.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100%"
+   height="100%"
+   viewBox="0 0 23.3551 10.420284"
+   version="1.1"
+   id="svg14694"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   sodipodi:docname="invenio-ils.svg">
+  <defs
+     id="defs14688" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="113.43261"
+     inkscape:cx="11.67755"
+     inkscape:cy="5.210142"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g25604"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="3440"
+     inkscape:window-height="1395"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata14691">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(77.678958,-138.68634)">
+    <a
+       transform="matrix(0.26458333,0,0,0.26458333,-307.94989,78.396553)"
+       style="display:inline"
+       id="a9728"
+       xlink:href="/products/ils/">
+      <g
+         transform="translate(1.7274613,2)"
+         id="g25604">
+        <g
+           id="g20666"
+           transform="matrix(0.43046721,0,0,0.43046721,548.44181,126.38329)">
+          <g
+             transform="translate(474.21725,226.44114)"
+             id="g20614">
+            <g
+               id="g20612">
+              <g
+                 id="g20610">
+                <path
+                   style="fill:#ffffff"
+                   id="path20608"
+                   d="m 328.162,4.665 c -18.767,0 -34.032,15.268 -34.032,34.034 0,7.28 2.306,14.028 6.214,19.568 l -30.078,26.432 c -1.881,1.878 0.067,6.867 1.944,8.749 1.879,1.876 6.87,3.822 8.748,1.943 l 26.265,-29.894 c 5.779,4.525 13.047,7.233 20.939,7.233 18.768,0 34.034,-15.267 34.034,-34.032 0,-18.765 -15.266,-34.033 -34.034,-34.033 z m 0,56.722 c -12.51,0 -22.689,-10.177 -22.689,-22.688 0,-12.511 10.18,-22.69 22.689,-22.69 12.513,0 22.688,10.18 22.688,22.69 0,12.51 -10.175,22.688 -22.688,22.688 z"
+                   inkscape:connector-curvature="0" />
+              </g>
+            </g>
+          </g>
+          <g
+             transform="matrix(0.38742049,0,0,0.38742049,670.93796,251.12579)"
+             id="g20620">
+            <path
+               style="fill:#ffffff"
+               id="path20616"
+               d="m 375.104,38.079 c 0.174,18.184 -8.123,32.126 -11.51,37.52 8.183,-5.347 19.898,-19.36 19.674,-37.661 0.174,-18.183 -11.431,-32.127 -19.631,-37.52 3.323,5.347 11.691,19.36 11.467,37.661 z"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:none;stroke:#ffffff"
+               id="path20618"
+               d="m 375.104,38.079 c 0.174,18.184 -8.123,32.126 -11.51,37.52 8.183,-5.347 19.898,-19.36 19.674,-37.661 0.174,-18.183 -11.431,-32.127 -19.631,-37.52 3.323,5.347 11.691,19.36 11.467,37.661 z"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+        <g
+           aria-label="ILS"
+           transform="scale(0.93553742,1.0689043)"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:37.67456436px;line-height:1.25;font-family:Oswald;-inkscape-font-specification:'Oswald, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#7be9ff;fill-opacity:1;stroke:none;stroke-width:7.62822819;stroke-miterlimit:4;stroke-dasharray:none"
+           id="text10216">
+          <path
+             id="path36621"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:37.67456436px;font-family:Oswald;-inkscape-font-specification:'Oswald, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#7be9ff;fill-opacity:1;stroke-width:7.62822819"
+             d="m 1014.9546,242.90421 q -2.8256,0 -4.7094,-1.01721 -1.8837,-1.05489 -2.8632,-3.12699 -0.9419,-2.10978 -1.0926,-5.34979 l 5.3498,-0.90419 q 0.075,1.88373 0.3767,3.16467 0.3391,1.24326 0.9796,1.88372 0.6781,0.6028 1.6577,0.6028 1.2056,0 1.62,-0.75349 0.4521,-0.7535 0.4521,-1.73303 0,-1.92141 -0.9419,-3.20234 -0.9042,-1.31861 -2.4112,-2.63722 l -3.1646,-2.75024 q -1.6954,-1.43164 -2.788,-3.24002 -1.0548,-1.80838 -1.0548,-4.4456 0,-3.76745 2.1851,-5.7642 2.2228,-2.03443 6.0656,-2.03443 2.2981,0 3.7674,0.75349 1.4694,0.75349 2.2605,2.03443 0.8289,1.24326 1.1303,2.75024 0.339,1.46931 0.4144,2.93862 l -5.3121,0.79116 q -0.075,-1.39396 -0.2638,-2.44884 -0.1507,-1.05489 -0.6781,-1.65769 -0.4898,-0.60279 -1.507,-0.60279 -1.0925,0 -1.62,0.82884 -0.5274,0.79117 -0.5274,1.77071 0,1.62 0.7158,2.67489 0.7535,1.01721 2.0344,2.14745 l 3.0893,2.71257 q 1.9214,1.65768 3.2777,3.80513 1.394,2.10978 1.394,5.23676 0,2.14745 -0.9796,3.88048 -0.9795,1.73303 -2.7502,2.71257 -1.733,0.97954 -4.1065,0.97954 z m -24.0264,-0.41442 v -30.5164 h 6.2163 v 26.29685 h 7.1582 v 4.21955 z m -10.81496,0 v -30.5164 h 6.17863 v 30.5164 z"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </a>
+  </g>
+</svg>

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -67,6 +67,8 @@ const uiConfig = {
       },
     },
   },
+  support_email: 'cds.support@cern.ch',
+  library_email: 'library.desk@cern.ch',
 };
 
 export const config = {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,22 +1,17 @@
-import { InvenioILSApp } from '@inveniosoftware/react-invenio-app-ils';
+import { history, InvenioILSApp } from '@inveniosoftware/react-invenio-app-ils';
 import React from 'react';
 import 'react-app-polyfill/ie11'; // For IE 11 support
 import ReactDOM from 'react-dom';
 import { OverridableContext } from 'react-overridable';
+import { Router } from 'react-router-dom';
 import 'semantic-ui-less/semantic.less';
 import { config } from './config';
 
-const CustomHome = ({ ...props }) => {
-  return <>CERN Library Catalogue</>;
-};
-
-const overriddenCmps = {
-  // 'Home.layout': CustomHome,
-};
-
 ReactDOM.render(
-  <OverridableContext.Provider value={overriddenCmps}>
-    <InvenioILSApp config={config} />
-  </OverridableContext.Provider>,
+  <Router history={history}>
+    <OverridableContext.Provider value={overriddenCmps}>
+      <InvenioILSApp config={config} />
+    </OverridableContext.Provider>
+  </Router>,
   document.getElementById('app')
 );

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -6,6 +6,7 @@ import { OverridableContext } from 'react-overridable';
 import { Router } from 'react-router-dom';
 import 'semantic-ui-less/semantic.less';
 import { config } from './config';
+import { overriddenCmps } from './overridableMapping';
 
 ReactDOM.render(
   <Router history={history}>

--- a/ui/src/overridableMapping.js
+++ b/ui/src/overridableMapping.js
@@ -1,0 +1,15 @@
+import { Footer } from './overriden/components/Footer/Footer';
+import {
+  RightMenuItem,
+  RightMenuItemMobile,
+} from './overriden/components/Menu/RightMenuItem';
+import { Home } from './overriden/frontsite/Home/Home';
+import { Slogan } from './overriden/frontsite/Home/Slogan';
+
+export const overriddenCmps = {
+  'Home.Headline.slogan': Slogan,
+  'Home.content': Home,
+  'Footer.layout': Footer,
+  'ILSMenu.RightMenuItems': RightMenuItem,
+  'ILSMenu.RightMenuItemsMobile': RightMenuItemMobile,
+};

--- a/ui/src/overriden/components/Footer/Footer.js
+++ b/ui/src/overriden/components/Footer/Footer.js
@@ -1,0 +1,80 @@
+import { FrontSiteRoutes } from '@inveniosoftware/react-invenio-app-ils';
+import Qs from 'qs';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Container, Grid, Header, List } from 'semantic-ui-react';
+
+export const Footer = ({ ...props }) => {
+  const onClickBookRequestLink = () => {
+    const params = Qs.parse(window.location.search);
+    const queryString = params['?q'];
+    return {
+      pathname: FrontSiteRoutes.documentRequestForm,
+      state: { queryString },
+    };
+  };
+
+  return (
+    <footer>
+      <Container fluid className="footer-upper">
+        <Container>
+          <Grid columns={3} stackable>
+            <Grid.Column>
+              <Header as="h4" content="CERN Library" />
+              <p>
+                Open 24 hours a day, <br />
+                every day of the year <br />
+                Staffed from 8.30 to 18.00, <br />
+                Monday-Friday
+              </p>
+            </Grid.Column>
+            <Grid.Column>
+              <Header as="h4" content="Help" />
+              <List>
+                <List.Item>
+                  <Link to={onClickBookRequestLink()}>Request literature</Link>
+                </List.Item>
+                <List.Item>
+                  <a href="#" target="_blank" rel="noopener noreferrer">
+                    F.A.Q.
+                  </a>
+                </List.Item>
+                <List.Item>
+                  <a
+                    href=" https://library.web.cern.ch "
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Scientific Information Service
+                  </a>
+                </List.Item>
+              </List>
+            </Grid.Column>
+            <Grid.Column>
+              <Header as="h4" content="Contact us" />
+              <List>
+                <List.Item>+41 22 767 24 35</List.Item>
+                <List.Item>
+                  <a href="mailto: library.desk@cern.ch">
+                    library.desk@cern.ch
+                  </a>
+                </List.Item>
+                <List.Item>
+                  <a href="mailto: cds.support@cern.ch">cds.support@cern.ch</a>
+                </List.Item>
+              </List>
+            </Grid.Column>
+          </Grid>
+        </Container>
+      </Container>
+      <Container fluid className="footer-lower">
+        <Container>
+          <Header as="h4" textAlign="center">
+            <Header.Content>Integrated Library System</Header.Content>
+            <Header.Subheader>Powered by INVENIO</Header.Subheader>
+          </Header>
+        </Container>
+      </Container>
+    </footer>
+  );
+};

--- a/ui/src/overriden/components/Footer/Footer.js
+++ b/ui/src/overriden/components/Footer/Footer.js
@@ -3,6 +3,7 @@ import Qs from 'qs';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Container, Grid, Header, List } from 'semantic-ui-react';
+import { config } from '../../../config';
 
 export const Footer = ({ ...props }) => {
   const onClickBookRequestLink = () => {
@@ -22,9 +23,10 @@ export const Footer = ({ ...props }) => {
             <Grid.Column>
               <Header as="h4" content="CERN Library" />
               <p>
-                Open 24 hours a day, <br />
+                Open 24 hours a day <br />
                 every day of the year <br />
-                Staffed from 8.30 to 18.00, <br />
+                <br />
+                Staffed from 8.30 to 18.00 <br />
                 Monday-Friday
               </p>
             </Grid.Column>
@@ -32,7 +34,9 @@ export const Footer = ({ ...props }) => {
               <Header as="h4" content="Help" />
               <List>
                 <List.Item>
-                  <Link to={onClickBookRequestLink()}>Request literature</Link>
+                  <Link to={onClickBookRequestLink()}>
+                    Request new literature
+                  </Link>
                 </List.Item>
                 <List.Item>
                   <a href="#" target="_blank" rel="noopener noreferrer">
@@ -55,12 +59,17 @@ export const Footer = ({ ...props }) => {
               <List>
                 <List.Item>+41 22 767 24 35</List.Item>
                 <List.Item>
-                  <a href="mailto: library.desk@cern.ch">
-                    library.desk@cern.ch
+                  <a href={`mailto:${config.uiConfig.library_email}`}>
+                    {config.uiConfig.library_email}
                   </a>
                 </List.Item>
+              </List>
+              <Header as="h4" content="Technical Support" />
+              <List>
                 <List.Item>
-                  <a href="mailto: cds.support@cern.ch">cds.support@cern.ch</a>
+                  <a href={`mailto:${config.uiConfig.support_email}`}>
+                    {config.uiConfig.support_email}
+                  </a>
                 </List.Item>
               </List>
             </Grid.Column>
@@ -70,8 +79,13 @@ export const Footer = ({ ...props }) => {
       <Container fluid className="footer-lower">
         <Container>
           <Header as="h4" textAlign="center">
-            <Header.Content>Integrated Library System</Header.Content>
-            <Header.Subheader>Powered by INVENIO</Header.Subheader>
+            <Header.Content>CERN Library Catalogue</Header.Content>
+            <Header.Subheader>
+              Powered by{' '}
+              <a href="https://inveniosoftware.org" target="_blank">
+                INVENIO
+              </a>
+            </Header.Subheader>
           </Header>
         </Container>
       </Container>

--- a/ui/src/overriden/components/Menu/RightMenuItem.js
+++ b/ui/src/overriden/components/Menu/RightMenuItem.js
@@ -3,6 +3,7 @@ import Qs from 'qs';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Dropdown, Menu, Responsive } from 'semantic-ui-react';
+import { config } from '../../../config';
 
 const onClickBookRequestLink = () => {
   const params = Qs.parse(window.location.search);
@@ -23,12 +24,12 @@ const dropdownEntries = (
       F.A.Q.
     </Dropdown.Item>
     <Dropdown.Divider />
-    <Dropdown.Item as="a" href="mailto: library.desk@cern.ch">
+    <Dropdown.Item as="a" href={`mailto:${config.uiConfig.library_email}`}>
       Ask a librarian
     </Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item as={Link} to={onClickBookRequestLink()}>
-      Request literature
+      Request new <br /> literature
     </Dropdown.Item>
   </Dropdown.Menu>
 );
@@ -37,7 +38,7 @@ export const RightMenuItem = ({ ...props }) => {
   return (
     <Menu.Item>
       <Responsive minWidth={Responsive.onlyTablet.minWidth}>
-        <Dropdown item text="Quick Access" icon="caret down">
+        <Dropdown item text="Help" icon="caret down">
           {dropdownEntries}
         </Dropdown>
       </Responsive>
@@ -48,7 +49,7 @@ export const RightMenuItem = ({ ...props }) => {
 export const RightMenuItemMobile = ({ ...props }) => {
   return (
     <Responsive {...Responsive.onlyMobile}>
-      <Dropdown item icon="linkify">
+      <Dropdown item icon="help">
         {dropdownEntries}
       </Dropdown>
     </Responsive>

--- a/ui/src/overriden/components/Menu/RightMenuItem.js
+++ b/ui/src/overriden/components/Menu/RightMenuItem.js
@@ -1,0 +1,56 @@
+import { FrontSiteRoutes } from '@inveniosoftware/react-invenio-app-ils';
+import Qs from 'qs';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Dropdown, Menu, Responsive } from 'semantic-ui-react';
+
+const onClickBookRequestLink = () => {
+  const params = Qs.parse(window.location.search);
+  const queryString = params['?q'];
+  return {
+    pathname: FrontSiteRoutes.documentRequestForm,
+    state: { queryString },
+  };
+};
+
+const dropdownEntries = (
+  <Dropdown.Menu>
+    <Dropdown.Item as="a" href="https://library.web.cern.ch/resources/remote">
+      External Online <br /> Resources
+    </Dropdown.Item>
+    <Dropdown.Divider />
+    <Dropdown.Item as="a" href="#">
+      F.A.Q.
+    </Dropdown.Item>
+    <Dropdown.Divider />
+    <Dropdown.Item as="a" href="mailto: library.desk@cern.ch">
+      Ask a librarian
+    </Dropdown.Item>
+    <Dropdown.Divider />
+    <Dropdown.Item as={Link} to={onClickBookRequestLink()}>
+      Request literature
+    </Dropdown.Item>
+  </Dropdown.Menu>
+);
+
+export const RightMenuItem = ({ ...props }) => {
+  return (
+    <Menu.Item>
+      <Responsive minWidth={Responsive.onlyTablet.minWidth}>
+        <Dropdown item text="Quick Access" icon="caret down">
+          {dropdownEntries}
+        </Dropdown>
+      </Responsive>
+    </Menu.Item>
+  );
+};
+
+export const RightMenuItemMobile = ({ ...props }) => {
+  return (
+    <Responsive {...Responsive.onlyMobile}>
+      <Dropdown item icon="linkify">
+        {dropdownEntries}
+      </Dropdown>
+    </Responsive>
+  );
+};

--- a/ui/src/overriden/frontsite/Home/Home.js
+++ b/ui/src/overriden/frontsite/Home/Home.js
@@ -1,0 +1,68 @@
+import {
+  documentApi,
+  DocumentCardGroup,
+  FrontSiteRoutes,
+} from '@inveniosoftware/react-invenio-app-ils';
+import React from 'react';
+import { Container } from 'semantic-ui-react';
+
+export const Home = () => {
+  return (
+    <Container fluid className="fs-landing-page-section-wrapper">
+      <Container fluid className="dot-background-container">
+        <Container fluid className="dot-background">
+          <Container textAlign="center" className="fs-landing-page-section">
+            <DocumentCardGroup
+              className="no-background"
+              title="Most Loaned Books"
+              headerClass="section-header highlight"
+              fetchDataMethod={documentApi.list}
+              fetchDataQuery={documentApi
+                .query()
+                .withDocumentType('BOOK')
+                .sortBy('-mostloaned')
+                .withSize(5)
+                .qs()}
+              viewAllUrl={FrontSiteRoutes.documentsListWithQuery(
+                '&sort=mostloaned&order=desc'
+              )}
+            />
+          </Container>
+        </Container>
+      </Container>
+      <Container textAlign="center" className="fs-landing-page-section">
+        <DocumentCardGroup
+          title="Most Recent Books"
+          headerClass="section-header highlight"
+          fetchDataMethod={documentApi.list}
+          fetchDataQuery={documentApi
+            .query()
+            .withDocumentType('BOOK')
+            .sortBy('mostrecent')
+            .withSize(5)
+            .qs()}
+          viewAllUrl={FrontSiteRoutes.documentsListWithQuery(
+            '&sort=mostrecent&order=desc'
+          )}
+        />
+      </Container>
+      <Container textAlign="center" className="fs-landing-page-section">
+        <DocumentCardGroup
+          title="Most Recent E-Books"
+          headerClass="section-header highlight"
+          fetchDataMethod={documentApi.list}
+          fetchDataQuery={documentApi
+            .query()
+            .withDocumentType('BOOK')
+            .withEitems()
+            .sortBy('-mostrecent')
+            .withSize(5)
+            .qs()}
+          viewAllUrl={FrontSiteRoutes.documentsListWithQuery(
+            '&f=doctype%3ABOOK&f=medium%3AELECTRONIC_VERSION&sort=mostrecent&order=desc'
+          )}
+        />
+      </Container>
+    </Container>
+  );
+};

--- a/ui/src/overriden/frontsite/Home/Home.js
+++ b/ui/src/overriden/frontsite/Home/Home.js
@@ -11,9 +11,11 @@ export const Home = () => {
     <Container fluid className="fs-landing-page-section-wrapper">
       <Container fluid className="dot-background-container">
         <Container fluid className="dot-background">
-          <Container textAlign="center" className="fs-landing-page-section">
+          <Container
+            textAlign="center"
+            className="fs-landing-page-section no-background"
+          >
             <DocumentCardGroup
-              className="no-background"
               title="Most Loaned Books"
               headerClass="section-header highlight"
               fetchDataMethod={documentApi.list}

--- a/ui/src/overriden/frontsite/Home/Slogan.js
+++ b/ui/src/overriden/frontsite/Home/Slogan.js
@@ -10,7 +10,7 @@ export const Slogan = ({ ...props }) => {
             CERN Library Catalogue
           </Header>
           <Header.Subheader className="fs-headline-subheader">
-            Find books fast and easily.
+            Books, e-books, papers, standards at CERN.
           </Header.Subheader>
         </Grid.Column>
       </Grid>

--- a/ui/src/overriden/frontsite/Home/Slogan.js
+++ b/ui/src/overriden/frontsite/Home/Slogan.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Container, Grid, Header } from 'semantic-ui-react';
+
+export const Slogan = ({ ...props }) => {
+  return (
+    <Container className="container-header">
+      <Grid>
+        <Grid.Column width={16} textAlign="left">
+          <Header as="h1" className="fs-headline-header" size="huge">
+            CERN Library Catalogue
+          </Header>
+          <Header.Subheader className="fs-headline-subheader">
+            Find books fast and easily.
+          </Header.Subheader>
+        </Grid.Column>
+      </Grid>
+    </Container>
+  );
+};

--- a/ui/src/semantic-ui/site/collections/menu.variables
+++ b/ui/src/semantic-ui/site/collections/menu.variables
@@ -1,4 +1,3 @@
 /*******************************
     Menu.overrides - CDS ILS
 *******************************/
-@highlightBorder: 2px solid rgba(174, 30, 206, 0.95) ;

--- a/ui/src/semantic-ui/site/elements/container.overrides
+++ b/ui/src/semantic-ui/site/elements/container.overrides
@@ -1,3 +1,12 @@
 /*******************************
          Site Overrides
 *******************************/
+
+/* Frontsite */
+@{fs-parent-selector} {
+  @{ui-container} {
+    &.fs-headline-section {
+      min-height: 65vh;
+    }
+  }
+}

--- a/ui/src/semantic-ui/site/globals/site.variables
+++ b/ui/src/semantic-ui/site/globals/site.variables
@@ -1,8 +1,3 @@
 /*******************************
    Site.Variables - CDS ILS
 *******************************/
-
-@fsPrimaryColor            : rgba(174, 30, 206, 0.95);
-@fsSecondaryColor          : #6899D0;
-
-@orange :  rgba(174, 30, 206, 0.95);

--- a/ui/src/semantic-ui/site/views/card.overrides
+++ b/ui/src/semantic-ui/site/views/card.overrides
@@ -4,8 +4,12 @@
 
 /* Frontsite */
 @{fs-parent-selector} {
-  .no-background.ui.cards > .card,
-  .ui.card {
-    background: none;
+  .container {
+    &.no-background {
+      .ui.cards > .card,
+      .ui.card {
+        background: none;
+      }
+    }
   }
 }

--- a/ui/src/semantic-ui/site/views/card.overrides
+++ b/ui/src/semantic-ui/site/views/card.overrides
@@ -1,3 +1,11 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+/* Frontsite */
+@{fs-parent-selector} {
+  .no-background.ui.cards > .card,
+  .ui.card {
+    background: none;
+  }
+}


### PR DESCRIPTION
closes #101

- Remove `popular topics`,  `our services` and section
- Customize footer 
- Change header to CERN library catalogue instead of Integrated library system
- Add Quick access menu in navigation bar 
- Change order of sections  
- Change background image minimum height to 65vh
- Remove purple color override
- Display max 5 books in each section
- Mobile view works correctly for homepage

**Screenshots**
Quick Access menu:
![Selection_003](https://user-images.githubusercontent.com/33685068/85689912-b93b8480-b6db-11ea-808a-bee02a0407fa.png)

![Selection_005](https://user-images.githubusercontent.com/33685068/85689882-b2147680-b6db-11ea-8059-415b02b9fdf1.png)


Sections + Footer:
![Selection_013](https://user-images.githubusercontent.com/33685068/85522374-3bf60e00-b60e-11ea-94b5-4e92f1b5a640.png)
![Selection_010](https://user-images.githubusercontent.com/33685068/85420101-76629b00-b57b-11ea-82cd-6a8e221a280b.png)
![Selection_007](https://user-images.githubusercontent.com/33685068/85690023-d3756280-b6db-11ea-8eca-6004dc58098b.png)
![Selection_006](https://user-images.githubusercontent.com/33685068/85690045-d83a1680-b6db-11ea-8106-25c3235a4be4.png)
